### PR TITLE
fix(bson-bench): fix utf8 option handling in Task#getResults()

### DIFF
--- a/packages/bson-bench/src/task.ts
+++ b/packages/bson-bench/src/task.ts
@@ -91,10 +91,12 @@ export class Task {
             break;
           // special cases
           case 'validation':
+            // utf8 validation is always on for bson-ext
             output['utf8Validation'] = /^bson-ext/.test(this.benchmark.library)
               ? 1
-              : typeof o[key] === 'boolean'
-              ? Number(o[key])
+              : // if value of boolean for js-bson, convert to number, otherwise assume true
+              typeof o[key]['utf8'] === 'boolean'
+              ? Number(o[key]['utf8'])
               : 1;
             break;
           default:

--- a/packages/bson-bench/test/unit/task.test.ts
+++ b/packages/bson-bench/test/unit/task.test.ts
@@ -115,20 +115,24 @@ describe('Task', function () {
         checkKeys: true,
         ignoreUndefined: false,
         serializeFunctions: false,
-        index: 0
+        index: 0,
+        validation: { utf8: false }
       };
 
       task = new Task({
         documentPath: 'test/documents/long_largeArray.json',
-        library: 'bson-ext@4.0.0',
+        library: 'bson@4.0.0',
         operation: 'deserialize',
         warmup: 1,
         iterations: 1,
         options
       });
 
-      await task.run();
-
+      task.result = {
+        durationMillis: Array.from({ length: 1000 }, () => 100),
+        documentSizeBytes: 100
+      };
+      task.hasRun = true;
       results = task.getResults();
     });
 
@@ -160,6 +164,64 @@ describe('Task', function () {
 
     it('returns numeric options provided in constructor as provided in the info.args field', function () {
       expect(results.info.args).to.haveOwnProperty('index', 0);
+    });
+
+    describe('when utf8 validation is enabled', function () {
+      const options = {
+        validation: { utf8: true }
+      };
+
+      let results: PerfSendResult;
+
+      before(() => {
+        const task = new Task({
+          documentPath: 'test/documents/long_largeArray.json',
+          library: 'bson@4.0.0',
+          operation: 'deserialize',
+          warmup: 1,
+          iterations: 1,
+          options
+        });
+        task.result = {
+          durationMillis: Array.from({ length: 1000 }, () => 100),
+          documentSizeBytes: 100
+        };
+        task.hasRun = true;
+        results = task.getResults();
+      });
+
+      it('info.args.utf8Validation is 1', function () {
+        expect(results.info.args).to.haveOwnProperty('utf8Validation', 1);
+      });
+    });
+
+    describe('when utf8Validation is disabled', function () {
+      const options = {
+        validation: { utf8: false }
+      };
+
+      let results: PerfSendResult;
+
+      before(() => {
+        const task = new Task({
+          documentPath: 'test/documents/long_largeArray.json',
+          library: 'bson@4.0.0',
+          operation: 'deserialize',
+          warmup: 1,
+          iterations: 1,
+          options
+        });
+        task.result = {
+          durationMillis: Array.from({ length: 1000 }, () => 100),
+          documentSizeBytes: 100
+        };
+        task.hasRun = true;
+        results = task.getResults();
+      });
+
+      it('info.args.utf8Validation is 0', function () {
+        expect(results.info.args).to.haveOwnProperty('utf8Validation', 0);
+      });
     });
   });
 


### PR DESCRIPTION
Fix how utf8 options are handled when generating results for perf.send