### PR TITLE
ci(NODE-6038): upgrade gha actions and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+### Description
+
+#### What is changing?
+
+##### Is there new documentation needed for these changes?
+
+#### What is the motivation for this change?
+
+<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
+<!-- If this is a feature, it helps to describe the new use case enabled by this change -->
+
+<!--
+Contributors!
+First of all, thank you so much!!
+If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
+You can do that here: https://jira.mongodb.org/projects/NODE
+-->
+
+### Release Highlight
+
+<!-- RELEASE_HIGHLIGHT_START -->
+
+### Fill in title or leave empty for no highlight
+
+<!-- RELEASE_HIGHLIGHT_END -->
+
+### Double check the following
+
+- [ ] Ran `npm run check:lint` script
+- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
+- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
+  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
+- [ ] Changes are covered by tests
+- [ ] New TODOs have a related JIRA ticket

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,14 +16,6 @@ If you haven't already, it would greatly help the team review this work in a tim
 You can do that here: https://jira.mongodb.org/projects/NODE
 -->
 
-### Release Highlight
-
-<!-- RELEASE_HIGHLIGHT_START -->
-
-### Fill in title or leave empty for no highlight
-
-<!-- RELEASE_HIGHLIGHT_END -->
-
 ### Double check the following
 
 - [ ] Ran `npm run check:eslint` script

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ You can do that here: https://jira.mongodb.org/projects/NODE
 
 ### Double check the following
 
-- [ ] Ran `npm run check:lint` script
+- [ ] Ran `npm run check:eslint` script
 - [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
 - [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
   - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,13 +22,13 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - name: npm install 
-      run: npm install 
+    - name: npm install
+      run: npm install
     - name: check lint
       run: npm run check:eslint

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,15 +21,15 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - name: install npm 9
       run: npm install -g npm@9
-    - name: npm install 
+    - name: npm install
       run: npm install
     - name: npm install workspaces
       run: npm install --workspaces


### PR DESCRIPTION
### Description

#### What is changing?

- Updated GHA
- Add dependabot monthly ping

##### Is there new documentation needed for these changes?

- No

#### What is the motivation for this change?

- Node.js 16 going EOL

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
