### PR TITLE
chore: add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
 
       - if: ${{ steps.release.outputs.release_created }}
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+name: release
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - id: release
+        uses: google-github-actions/release-please-action@v4
+
+      - if: ${{ steps.release.outputs.release_created }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - if: ${{ steps.release.outputs.release_created }}
+        run: npm install -g npm@latest
+        shell: bash
+
+      - if: ${{ steps.release.outputs.release_created }}
+        run: npm clean-install
+        shell: bash
+
+      - if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@v4
+
+      - if: ${{ steps.release.outputs.release_created }}
+        run: npm publish --workspaces
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/bson-bench/package.json
+++ b/packages/bson-bench/package.json
@@ -2,7 +2,12 @@
   "name": "bson-bench",
   "version": "0.0.1",
   "description": "benchmarking tool for bson",
-  "private": true,
+  "files": [
+    "lib",
+    "src",
+    "etc/prepare.js",
+    "tsconfig.json"
+  ],
   "main": "./lib/index.js",
   "scripts": {
     "build": "npx tsc -p ./tsconfig.json",
@@ -18,9 +23,5 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bson": "4.7"
-  },
-  "directories": {
-    "lib": "lib",
-    "test": "test"
   }
 }


### PR DESCRIPTION
### Description

#### What is changing?

- Adds release automation

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

To try and get out tooling packages into a built release.

### Double check the following

- [ ] Ran `npm run check:eslint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
