### PR TITLE
chore: fix benchmark result reporting

### DIFF
--- a/packages/bson-bench/src/base.ts
+++ b/packages/bson-bench/src/base.ts
@@ -19,7 +19,7 @@ function exit(code: number) {
 
 function reportResultAndQuit(result: BenchmarkResult) {
   if (process.send) {
-    process?.send({ type: 'returnResult', result }, null, {}, () => exit(0));
+    process.send({ type: 'returnResult', result }, null, {}, () => exit(0));
     return;
   }
   exit(0);
@@ -27,7 +27,7 @@ function reportResultAndQuit(result: BenchmarkResult) {
 
 function reportErrorAndQuit(error: Error) {
   if (process.send) {
-    process?.send(
+    process.send(
       {
         type: 'returnError',
         error

--- a/packages/bson-bench/src/base.ts
+++ b/packages/bson-bench/src/base.ts
@@ -12,20 +12,34 @@ import {
   type RunBenchmarkMessage
 } from './common';
 
-function reportResultAndQuit(result: BenchmarkResult) {
-  if (process.send) process?.send({ type: 'returnResult', result });
+function exit(code: number) {
   process.disconnect();
-  process.exit(0);
+  process.exit(code);
+}
+
+function reportResultAndQuit(result: BenchmarkResult) {
+  if (process.send) {
+    process?.send({ type: 'returnResult', result }, null, {}, () => exit(0));
+    return;
+  }
+  exit(0);
 }
 
 function reportErrorAndQuit(error: Error) {
-  if (process.send)
-    process.send({
-      type: 'returnError',
-      error
-    });
-  process.disconnect();
-  process.exit(1);
+  if (process.send) {
+    process?.send(
+      {
+        type: 'returnError',
+        error
+      },
+      null,
+      {},
+      () => exit(0)
+    );
+    return;
+  }
+
+  exit(1);
 }
 
 function run(bson: BSONLib | ConstructibleBSON, config: BenchmarkSpecification) {


### PR DESCRIPTION
### Description

#### What is changing?

The benchmark runner disconnects and exits the process before process.send has finished reporting the results to the parent process.

This PR waits until the process.send has finished before exiting.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:eslint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
