### PR TITLE
fix(NODE-6357): strip version/branch/tag from test name

### DIFF
--- a/packages/bson-bench/src/suite.ts
+++ b/packages/bson-bench/src/suite.ts
@@ -43,10 +43,10 @@ export class Suite {
         (e: Error) => e
       );
       if (result instanceof Error) {
-        console.log(`\t${task.taskName} ✗`);
+        console.log(`\t${task.testName} ✗`);
         this._errors.push({ task, error: result });
       } else {
-        console.log(`\t${task.taskName} ✓`);
+        console.log(`\t${task.testName} ✓`);
         this._results.push(result);
       }
     }

--- a/packages/bson-bench/src/task.ts
+++ b/packages/bson-bench/src/task.ts
@@ -19,6 +19,7 @@ export class Task {
   result: BenchmarkResult | undefined;
   benchmark: BenchmarkSpecification;
   taskName: string;
+  testName: string;
   /** @internal */
   children: ChildProcess[];
   /** @internal */
@@ -33,6 +34,8 @@ export class Task {
     this.taskName = `${path.basename(this.benchmark.documentPath, 'json')}_${
       this.benchmark.operation
     }_${this.benchmark.library}`;
+
+    this.testName = this.taskName.substring(0, this.taskName.search(/#|@/));
   }
 
   /**
@@ -111,7 +114,7 @@ export class Task {
 
     const perfSendResults: PerfSendResult = {
       info: {
-        test_name: this.taskName,
+        test_name: this.testName,
         args: {
           warmup: this.benchmark.warmup,
           iterations: this.benchmark.iterations,


### PR DESCRIPTION
### Description

Strips the version, tag, or branch name from the individual benchmark test names.

#### What is changing?

- benchmark_bson@x.x.x strips everything after the @ 
- benchmark_bson#tag strips everything after the # 

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6357

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:eslint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
