### PR TITLE
chore: add csv parsing script for performance comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "name": "dbx-js-tools",
       "workspaces": [
         "packages/bson-bench",
-        "packages/driver-bench"
+        "packages/driver-bench",
+        "packages/metrics"
       ],
       "devDependencies": {
         "@tsconfig/node16": "^16.1.3",
@@ -883,6 +884,39 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csv": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-6.3.10.tgz",
+      "integrity": "sha512-5NYZG4AN2ZUthmNxIudgBEdMPUnbQHu9V4QTzBPqQzUP3KQsFiJo+8HQ0+oVxj1PomIT1/f67VI1QH/hsrZLKA==",
+      "license": "MIT",
+      "dependencies": {
+        "csv-generate": "^4.4.1",
+        "csv-parse": "^5.5.6",
+        "csv-stringify": "^6.5.1",
+        "stream-transform": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 0.1.90"
+      }
+    },
+    "node_modules/csv-generate": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-4.4.1.tgz",
+      "integrity": "sha512-O/einO0v4zPmXaOV+sYqGa02VkST4GP5GLpWBNHEouIU7pF3kpGf3D0kCCvX82ydIY4EKkOK+R8b1BYsRXravg==",
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.6.tgz",
+      "integrity": "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A==",
+      "license": "MIT"
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.5.1.tgz",
+      "integrity": "sha512-+9lpZfwpLntpTIEpFbwQyWuW/hmI/eHuJZD1XzeZpfZTqkf1fyvBbBLXTJJMsBuuS11uTShMqPwzx4A6ffXgRQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.6",
@@ -1772,6 +1806,10 @@
         "node": ">= 8"
       }
     },
+    "node_modules/metrics": {
+      "resolved": "packages/metrics",
+      "link": true
+    },
     "node_modules/micromatch": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
@@ -2241,6 +2279,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/stream-transform": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-3.3.2.tgz",
+      "integrity": "sha512-v64PUnPy9Qw94NGuaEMo+9RHQe4jTBYf+NkTtqkCgeuiNo8NlL0LtLR7fkKWNVFtp3RhIm5Dlxkgm5uz7TDimQ==",
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "dev": true,
@@ -2641,6 +2685,16 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-tsdoc": "^0.2.17"
+      }
+    },
+    "packages/metrics": {
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "csv": "^6.3.10"
+      },
+      "bin": {
+        "mndb": "lib/cli.mjs"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "workspaces": [
     "packages/bson-bench",
-    "packages/driver-bench"
+    "packages/driver-bench",
+    "packages/metrics"
   ],
   "devDependencies": {
     "@tsconfig/node16": "^16.1.3",

--- a/packages/metrics/.gitignore
+++ b/packages/metrics/.gitignore
@@ -1,0 +1,2 @@
+data/*.csv
+data/*.json

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "metrics",
+    "version": "1.0.0",
+    "description": "helpers for parsing performance results",
+    "module": "./lib/mod.mjs",
+    "bin": {
+        "mndb": "./lib/cli.mjs"
+    },
+    "scripts": {
+        "start": "node --disable-warning=ExperimentalWarning --experimental-strip-types src/main.mts"
+    },
+    "keywords": [],
+    "author": "The MongoDB NodeJS Team <dbx-node@mongodb.com>",
+    "license": "Apache-2.0",
+    "dependencies": {
+        "csv": "^6.3.10"
+    }
+}

--- a/packages/metrics/src/main.mts
+++ b/packages/metrics/src/main.mts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import stream from 'node:stream/promises';
+
+import * as csv from 'csv';
+
+const NUM_HEADERS = ['base_mean', 'compare_mean', 'percent_change'];
+const HEADERS = ['task', 'test', 'measurement', ...NUM_HEADERS];
+
+await stream.pipeline(
+  fs.createReadStream('./data/Data.csv', 'utf8'),
+  csv.parse({ columns: true }),
+  csv.transform(record =>
+    Object.fromEntries(
+      Object.entries(record)
+        .filter(([header]) => HEADERS.includes(header))
+        .map(([header, value]) => [header, NUM_HEADERS.includes(header) ? Number(value) : value])
+    )
+  ),
+  async (source: csv.transformer.Transformer) =>
+    console.table((await source.toArray()).toSorted((a, b) => a.percent_change - b.percent_change))
+);

--- a/packages/metrics/tsconfig.json
+++ b/packages/metrics/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "outDir": "lib",
+    "strict": false,
+    "verbatimModuleSyntax": true,
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
### Description

#### What is changing?

- Add a place for us to put CSV / JSON comparing scripts

##### Is there new documentation needed for these changes?

- No

#### What is the motivation for this change?

I often rewrite the same ~5/10 lines of JS to compare results of performance tests. I'd like to keep some of them stored somewhere.

### Double check the following

- [x] Ran `npm run check:eslint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
