### PR TITLE
feat(NODE-6757): support tags for perf.send

### DIFF
--- a/packages/bson-bench/src/common.ts
+++ b/packages/bson-bench/src/common.ts
@@ -134,6 +134,7 @@ export type BenchmarkSpecification = {
    * local package */
   library: string;
   installLocation?: string;
+  tags?: string[];
 };
 
 export interface RunBenchmarkMessage {

--- a/packages/bson-bench/src/task.ts
+++ b/packages/bson-bench/src/task.ts
@@ -22,7 +22,6 @@ export class Task {
   benchmark: Omit<BenchmarkSpecification, 'installLocation'> & { installLocation: string };
   taskName: string;
   testName: string;
-  tags?: string[];
   /** @internal */
   children: ChildProcess[];
   /** @internal */
@@ -34,7 +33,6 @@ export class Task {
     this.result = undefined;
     this.children = [];
     this.hasRun = false;
-    this.tags = benchmarkSpec.tags;
     this.benchmark = { ...benchmarkSpec, installLocation: Task.packageInstallLocation };
 
     this.taskName = `${path.basename(this.benchmark.documentPath, 'json')}_${
@@ -121,7 +119,7 @@ export class Task {
     const perfSendResults: PerfSendResult = {
       info: {
         test_name: this.testName,
-        tags: this.tags,
+        tags: this.benchmark.tags,
         args: {
           warmup: this.benchmark.warmup,
           iterations: this.benchmark.iterations,

--- a/packages/bson-bench/src/task.ts
+++ b/packages/bson-bench/src/task.ts
@@ -22,6 +22,7 @@ export class Task {
   benchmark: Omit<BenchmarkSpecification, 'installLocation'> & { installLocation: string };
   taskName: string;
   testName: string;
+  tags?: string[];
   /** @internal */
   children: ChildProcess[];
   /** @internal */
@@ -33,6 +34,7 @@ export class Task {
     this.result = undefined;
     this.children = [];
     this.hasRun = false;
+    this.tags = benchmarkSpec.tags;
     this.benchmark = { ...benchmarkSpec, installLocation: Task.packageInstallLocation };
 
     this.taskName = `${path.basename(this.benchmark.documentPath, 'json')}_${
@@ -119,6 +121,7 @@ export class Task {
     const perfSendResults: PerfSendResult = {
       info: {
         test_name: this.testName,
+        tags: this.tags,
         args: {
           warmup: this.benchmark.warmup,
           iterations: this.benchmark.iterations,

--- a/packages/bson-bench/test/unit/suite.test.ts
+++ b/packages/bson-bench/test/unit/suite.test.ts
@@ -88,7 +88,8 @@ describe('Suite', function () {
         warmup: 10,
         iterations: 10,
         library: 'bson@5.0.0',
-        options: {}
+        options: {},
+        tags: ['test']
       };
       suite
         .task({

--- a/packages/bson-bench/test/unit/task.test.ts
+++ b/packages/bson-bench/test/unit/task.test.ts
@@ -215,7 +215,8 @@ describe('Task', function () {
         operation: 'deserialize',
         warmup: 1,
         iterations: 1,
-        options
+        options,
+        tags: ['test', 'test2']
       });
 
       task.result = {
@@ -229,6 +230,10 @@ describe('Task', function () {
     it('returns results as an object', async function () {
       expect(results.info).to.haveOwnProperty('test_name', task.testName);
       expect(results.info).to.haveOwnProperty('args');
+    });
+
+    it('returns the tags in the info.tags field', function () {
+      expect(results.info.tags).to.deep.equal(['test', 'test2']);
     });
 
     it('returns options provided in constructor in the info.args field', function () {

--- a/packages/bson-bench/test/unit/task.test.ts
+++ b/packages/bson-bench/test/unit/task.test.ts
@@ -78,10 +78,6 @@ describe('Task', function () {
           expect(task.testName).to.not.include(test.library);
           expect(task.testName).to.match(/bson|bson-ext/);
         });
-
-        it('collects the tags correctly', function () {
-          expect(task.tags).to.deep.equal(['test']);
-        });
       });
     }
 

--- a/packages/bson-bench/test/unit/task.test.ts
+++ b/packages/bson-bench/test/unit/task.test.ts
@@ -79,7 +79,7 @@ describe('Task', function () {
           expect(task.testName).to.match(/bson|bson-ext/);
         });
 
-        it('collects the tags correctly', function() {
+        it('collects the tags correctly', function () {
           expect(task.tags).to.deep.equal(['test']);
         });
       });

--- a/packages/bson-bench/test/unit/task.test.ts
+++ b/packages/bson-bench/test/unit/task.test.ts
@@ -42,7 +42,8 @@ describe('Task', function () {
           operation,
           warmup: 100,
           iterations: 100,
-          options: {}
+          options: {},
+          tags: ['test']
         }
       ];
     })
@@ -76,6 +77,10 @@ describe('Task', function () {
         it('strips the tag or commit from the test name', function () {
           expect(task.testName).to.not.include(test.library);
           expect(task.testName).to.match(/bson|bson-ext/);
+        });
+
+        it('collects the tags correctly', function() {
+          expect(task.tags).to.deep.equal(['test']);
         });
       });
     }


### PR DESCRIPTION
### Description

#### What is changing?
Supports tags for perf.send results

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?
Perf monitoring improvements NODE-6757
<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [X] Ran `npm run check:eslint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
