### PR TITLE
fix(NODE-6706): Move creation and deletion of install location

### DIFF
--- a/packages/bson-bench/test/unit/task.test.ts
+++ b/packages/bson-bench/test/unit/task.test.ts
@@ -25,7 +25,7 @@ describe('Task', function () {
 
   const BSON_PATH = process.env.BSON_PATH;
   const BSON_EXT_PATH = process.env.BSON_EXT_PATH;
-  const versions = ['bson@6.2.0', 'bson@4.0.0', 'bson@5.0.1', 'bson#v6.1.0', `bson:${LOCAL_BSON}`];
+  const versions = ['bson@6.2.0', 'bson@4.0.0', 'bson@5.0.0', 'bson#v6.1.0', `bson:${LOCAL_BSON}`];
   const operations: ('serialize' | 'deserialize')[] = ['serialize', 'deserialize'];
   if (BSON_PATH) versions.push(`bson:${BSON_PATH}`);
   if (BSON_EXT_PATH) versions.push(`bson:${BSON_EXT_PATH}`);

--- a/packages/bson-bench/test/unit/task.test.ts
+++ b/packages/bson-bench/test/unit/task.test.ts
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
-import { rm } from 'fs/promises';
+import { mkdir, rm } from 'fs/promises';
 import * as path from 'path';
 
+import { Suite } from '../../lib/suite';
 import { Task } from '../../lib/task';
 import { type BenchmarkSpecification, type PerfSendResult } from '../../src/common';
 import { exists } from '../../src/utils';
@@ -10,17 +11,21 @@ import { clearTestedDeps } from '../utils';
 const LOCAL_BSON = path.join(__dirname, '..', '..', 'node_modules', 'bson');
 
 describe('Task', function () {
+  before(async function () {
+    if (!(await exists(Suite.packageInstallLocation))) await mkdir(Suite.packageInstallLocation);
+  });
+
   beforeEach(async function () {
-    await clearTestedDeps(Task.packageInstallLocation);
+    await clearTestedDeps(Suite.packageInstallLocation);
   });
 
   after(async function () {
-    await clearTestedDeps(Task.packageInstallLocation);
+    await rm(Suite.packageInstallLocation, { recursive: true, force: true });
   });
 
   const BSON_PATH = process.env.BSON_PATH;
   const BSON_EXT_PATH = process.env.BSON_EXT_PATH;
-  const versions = ['bson@6.2.0', 'bson@4.0.0', 'bson@5.0.0', 'bson#v6.1.0', `bson:${LOCAL_BSON}`];
+  const versions = ['bson@6.2.0', 'bson@4.0.0', 'bson@5.0.1', 'bson#v6.1.0', `bson:${LOCAL_BSON}`];
   const operations: ('serialize' | 'deserialize')[] = ['serialize', 'deserialize'];
   if (BSON_PATH) versions.push(`bson:${BSON_PATH}`);
   if (BSON_EXT_PATH) versions.push(`bson:${BSON_EXT_PATH}`);
@@ -98,71 +103,6 @@ describe('Task', function () {
 
         expect(maybeError).to.be.instanceOf(Error);
         expect(maybeError).to.have.property('message', 'failed to serialize input object');
-      });
-
-      it('deletes the temp directory', async function () {
-        const task = new Task({
-          documentPath: 'test/documents/array.json',
-          library: 'bson@5',
-          operation: 'deserialize',
-          warmup: 100,
-          iterations: 100,
-          options: {}
-        });
-
-        // bson throws error when passed array as top-level input
-        const maybeError = await task.run().catch(e => e);
-
-        expect(maybeError).to.be.instanceOf(Error);
-        expect(maybeError).to.have.property('message', 'failed to serialize input object');
-
-        const tmpdirExists = await exists(Task.packageInstallLocation);
-        expect(tmpdirExists).to.be.false;
-      });
-    });
-
-    it('creates a temp directory for packages', async function () {
-      const task = new Task({
-        documentPath: 'test/documents/long_largeArray.json',
-        library: 'bson@5',
-        operation: 'deserialize',
-        warmup: 100,
-        iterations: 10000,
-        options: {}
-      });
-
-      const checkForDirectory = async () => {
-        for (let i = 0; i < 10; i++) {
-          if (await exists(Task.packageInstallLocation)) return true;
-        }
-        return false;
-      };
-      const taskRunPromise = task.run().catch(e => e);
-
-      const result = await Promise.race([checkForDirectory(), taskRunPromise]);
-      expect(typeof result).to.equal('boolean');
-      expect(result).to.be.true;
-
-      const taskRunResult = await taskRunPromise;
-      expect(taskRunResult).to.not.be.instanceOf(Error);
-    });
-
-    context('after completing successfully', function () {
-      it('deletes the temp directory', async function () {
-        const task = new Task({
-          documentPath: 'test/documents/long_largeArray.json',
-          library: 'bson@5',
-          operation: 'deserialize',
-          warmup: 100,
-          iterations: 100,
-          options: {}
-        });
-
-        const maybeError = await task.run().catch(e => e);
-        expect(maybeError).to.not.be.instanceOf(Error);
-
-        const tmpdirExists = await exists(Task.packageInstallLocation);
-        expect(tmpdirExists).to.be.false;
       });
     });
   });


### PR DESCRIPTION
### Description

#### What is changing?
* move creation and removal of install directory to `Suite.run` from `Task.run`
* Move tests for creation and removal of install directory to suite.test.ts from task.test.ts

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [X] Ran `npm run check:eslint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
