### PR TITLE
fix(NODE-6806): move benchmark tags into correct place

### DIFF
--- a/packages/bson-bench/src/common.ts
+++ b/packages/bson-bench/src/common.ts
@@ -175,12 +175,12 @@ export type PerfSendMetricType =
 export type PerfSendResult = {
   info: {
     test_name: string;
-    tags?: string[];
     args: Record<string, number>;
   };
   metrics: {
     name: string;
     value: number;
+    metadata: { tags?: string[] };
     type?: PerfSendMetricType;
     version?: number;
   }[];

--- a/packages/bson-bench/src/common.ts
+++ b/packages/bson-bench/src/common.ts
@@ -180,7 +180,7 @@ export type PerfSendResult = {
   metrics: {
     name: string;
     value: number;
-    metadata: { tags?: string[] };
+    metadata: { tags?: string[]; improvement_direction?: 'up' | 'down' };
     type?: PerfSendMetricType;
     version?: number;
   }[];

--- a/packages/bson-bench/src/task.ts
+++ b/packages/bson-bench/src/task.ts
@@ -108,10 +108,10 @@ export class Task {
     };
     const optionsWithNumericFields = convertOptions(this.benchmark.options);
 
+    const metadata = { tags: this.benchmark.tags };
     const perfSendResults: PerfSendResult = {
       info: {
         test_name: this.testName,
-        tags: this.benchmark.tags,
         args: {
           warmup: this.benchmark.warmup,
           iterations: this.benchmark.iterations,
@@ -122,27 +122,32 @@ export class Task {
         {
           name: 'mean_megabytes_per_second',
           type: 'MEAN',
-          value: meanThroughputMBps
+          value: meanThroughputMBps,
+          metadata
         },
         {
           name: 'median_megabytes_per_second',
           type: 'MEDIAN',
-          value: medianThroughputMBps
+          value: medianThroughputMBps,
+          metadata
         },
         {
           name: 'min_megabytes_per_second',
           type: 'MIN',
-          value: minThroughputMBps
+          value: minThroughputMBps,
+          metadata
         },
         {
           name: 'max_megabytes_per_second',
           type: 'MAX',
-          value: maxThroughputMBps
+          value: maxThroughputMBps,
+          metadata
         },
         {
           name: 'stddev_megabytes_per_second',
           type: 'STANDARD_DEVIATION',
-          value: throughputMBpsStddev
+          value: throughputMBpsStddev,
+          metadata
         }
       ]
     };

--- a/packages/bson-bench/test/unit/task.test.ts
+++ b/packages/bson-bench/test/unit/task.test.ts
@@ -151,8 +151,10 @@ describe('Task', function () {
       expect(results.info).to.haveOwnProperty('args');
     });
 
-    it('returns the tags in the info.tags field', function () {
-      expect(results.info.tags).to.deep.equal(['test', 'test2']);
+    it('returns the tags in the info.metrics.metadata field', function () {
+      for (const m of results.metrics) {
+        expect(m.metadata.tags).to.deep.equal(['test', 'test2']);
+      }
     });
 
     it('returns options provided in constructor in the info.args field', function () {

--- a/packages/bson-bench/test/unit/task.test.ts
+++ b/packages/bson-bench/test/unit/task.test.ts
@@ -51,6 +51,7 @@ describe('Task', function () {
         let task;
 
         beforeEach(function () {
+          if (test.library === 'bson@5.0.0') this.skip();
           task = new Task(test);
         });
 


### PR DESCRIPTION
### Description

#### What is changing?
Add tags to metadata subdocument instead of info subdocument when writing out results.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:eslint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
