### PR TITLE
chore: Update dependabot.yml to allow prod dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,14 @@ updates:
       # we ignore TS as a part of quarterly dependency updates.
       - dependency-name: "typescript"
     versioning-strategy: increase
-    allow:
-      - dependency-type: "development"
-      
+
     groups:
+      prod-dependencies:
+        dependency-type: "production"
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"    
       development-dependencies:
         dependency-type: "development"
         applies-to: version-updates


### PR DESCRIPTION
### Description

#### What is changing?
Adding a prod-dependencies group to the dependabot config; technically there are no prod dependencies here, but keeping the config consistent across our repos makes it easier to maintain.

##### Is there new documentation needed for these changes?
N/A

#### What is the motivation for this change?
Future-proofing convenience of dependency updates


### Double check the following

- [ ] Ran `npm run check:eslint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
